### PR TITLE
New: update cache file after ~/.ssh/config is modified

### DIFF
--- a/ssh.plugin.zsh
+++ b/ssh.plugin.zsh
@@ -1,8 +1,14 @@
 #!/usr/bin/env zsh
 
 hosts=()
-if [ -f ~/.ssh/config ]; then
-  hosts=( $(grep '^Host' ~/.ssh/config | awk '{first = $1; $1 = ""; print $0; }' | xargs) )
+cache_file="${TMPDIR:-/tmp}/zpm-zsh-ssh-cache.$UID.zsh"
+if [[ -f ~/.ssh/config ]]; then
+  if [[ ~/.ssh/config -nt "$cache_file" || ! -s "$cache_file"  ]]; then
+    hosts=( $(grep '^Host' ~/.ssh/config | awk '{first = $1; $1 = ""; print $0; }' | xargs) )
+    typeset -p hosts >! "$cache_file" 2> /dev/null
+  else
+    source "$cache_file"
+  fi
 fi
 
 


### PR DESCRIPTION
A useful skill learned from prezto module fasd. In this case,
it reduces the loading time from 11ms to 1ms on my machine.

Cache the array `hosts` into a file, then read in the array `hosts` from cache file in later startups. Re-cache it whenever `~/.ssh/config` is updated.